### PR TITLE
Add minimal FastAPI backend with core endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="Mantua Protocol Backend")
+
+
+class QueryRequest(BaseModel):
+    """Input for natural language queries to the LLM."""
+    query: str
+
+
+class SimulateRequest(BaseModel):
+    """Details about a DeFi action to simulate."""
+    action: str
+    params: Dict[str, Any] = {}
+
+
+class ExecuteRequest(BaseModel):
+    """Signed transaction execution parameters."""
+    tx: str
+    network: str
+
+
+@app.post("/query")
+async def query(req: QueryRequest) -> Dict[str, Any]:
+    """Handle natural language queries by delegating to the LLM."""
+    # Placeholder logic for Mantua Protocol engine integration
+    return {"response": f"Echo: {req.query}"}
+
+
+@app.post("/simulate")
+async def simulate(req: SimulateRequest) -> Dict[str, Any]:
+    """Simulate DeFi actions like swaps or LP adjustments."""
+    # Placeholder simulation logic
+    return {"action": req.action, "status": "simulated", "params": req.params}
+
+
+@app.post("/execute")
+async def execute(req: ExecuteRequest) -> Dict[str, Any]:
+    """Execute signed transactions on chain."""
+    # Stub execution result
+    return {"network": req.network, "tx": req.tx, "status": "submitted"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- Implement FastAPI app exposing /query, /simulate, and /execute endpoints
- Provide basic request models and placeholder responses
- Add initial requirements for FastAPI backend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8cb1447788329b65396528c209eb2