### PR TITLE
Add minimal Mantua client and FastAPI server

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -1,0 +1,177 @@
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from typing import Optional, List, AsyncGenerator
+import asyncio
+import json
+import os
+
+# --- OpenAI (server-side) ---
+try:
+    from openai import OpenAI
+except ImportError:
+    OpenAI = None  # handle missing dep gracefully
+
+app = FastAPI()
+
+# ---- CORS (dev-friendly) ----
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],      # tighten in prod
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# ---- Config (env) ----
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "")  # e.g., ft:gpt-4o-mini:your-org:mantua-v1
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "")  # optional (Azure/compatible)
+
+_client = None
+if OpenAI and OPENAI_API_KEY:
+    # If you use an alt endpoint, set base_url via env
+    _client = OpenAI(api_key=OPENAI_API_KEY, base_url=OPENAI_BASE_URL or None)
+
+# ---- Models ----
+class ContextFilters(BaseModel):
+    chain_ids: Optional[List[str]] = None
+    contract_addresses: Optional[List[str]] = None
+    wallet_addresses: Optional[List[str]] = None
+    token_addresses: Optional[List[str]] = None
+    # extend as needed (protocols, pool_ids, metrics, etc.)
+
+class ChatRequest(BaseModel):
+    message: str
+    stream: bool = False
+    session_id: Optional[str] = None
+    context: Optional[ContextFilters] = None
+
+class SimulateRequest(BaseModel):
+    scenario: str
+    session_id: Optional[str] = None
+    context: Optional[ContextFilters] = None
+
+class ExecuteRequest(BaseModel):
+    action: str
+    session_id: Optional[str] = None
+    context: Optional[ContextFilters] = None
+    execute_config: Optional[dict] = None  # signer, mode, etc.
+
+# ---- Helpers ----
+def _chat_messages(user_message: str, context: Optional[ContextFilters], session_id: Optional[str]):
+    sys_ctx = {
+        "session_id": session_id,
+        "context": (context.dict() if context else None),
+        "policy": "Do not invent addresses. Respect provided chain_ids and contract_addresses."
+    }
+    system = (
+        "You are Mantua's on-chain assistant. Use the provided context to ground answers. "
+        "If data is missing, be explicit. Keep responses concise and action-oriented."
+        f"\n<ctx>{json.dumps(sys_ctx)}</ctx>"
+    )
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user_message},
+    ]
+
+async def _stream_openai_tokens(messages):
+    """Yield SSE frames from OpenAI streaming."""
+    if not _client or not OPENAI_MODEL:
+        # Fallback: simple echo streaming
+        chunks = ["[fallback-start]", " OpenAI not configured. ", "Echo: ", messages[-1]["content"], " [fallback-end]"]
+        for c in chunks:
+            yield f"data: {json.dumps({'type':'token','content': c})}\n\n".encode("utf-8")
+            await asyncio.sleep(0.03)
+        yield b"data: {\"type\":\"done\"}\n\n"
+        return
+
+    stream = _client.chat.completions.create(
+        model=OPENAI_MODEL,
+        messages=messages,
+        temperature=0.2,
+        stream=True,
+    )
+
+    # optional: send a start event
+    yield f"data: {json.dumps({'type':'start'})}\n\n".encode("utf-8")
+
+    try:
+        for event in stream:
+            delta = event.choices[0].delta if event.choices else None
+            token = getattr(delta, "content", None)
+            if token:
+                yield f"data: {json.dumps({'type':'token','content': token})}\n\n".encode("utf-8")
+        # completed
+        yield b"data: {\"type\":\"done\"}\n\n"
+    except Exception as e:
+        # surface an error event but keep SSE well-formed
+        yield f"data: {json.dumps({'type':'error','message': str(e)})}\n\n".encode("utf-8")
+        yield b"data: {\"type\":\"done\"}\n\n"
+
+def _complete_openai(messages) -> str:
+    """Return a full completion (no streaming)."""
+    if not _client or not OPENAI_MODEL:
+        return f"[fallback] OpenAI not configured. Echo: {messages[-1]['content']}"
+    resp = _client.chat.completions.create(
+        model=OPENAI_MODEL,
+        messages=messages,
+        temperature=0.2,
+    )
+    return (resp.choices[0].message.content or "").strip()
+
+# ---- Endpoints ----
+@app.post("/chat")
+async def chat_endpoint(request: ChatRequest):
+    """
+    Natural language chat: proxies to OpenAI (server-side) or falls back.
+    stream=True -> SSE; otherwise -> JSON.
+    """
+    messages = _chat_messages(request.message, request.context, request.session_id)
+
+    if request.stream:
+        async def event_generator() -> AsyncGenerator[bytes, None]:
+            # Context ack (optional)
+            ack = {
+                "type": "context_ack",
+                "session_id": request.session_id,
+                "context": (request.context.dict() if request.context else None),
+                "model": OPENAI_MODEL or "fallback",
+            }
+            yield f"data: {json.dumps(ack)}\n\n".encode("utf-8")
+            async for frame in _stream_openai_tokens(messages):
+                yield frame
+        return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+    # Non-streaming
+    content = _complete_openai(messages)
+    return {
+        "response": content,
+        "session_id": request.session_id,
+        "context": (request.context.dict() if request.context else None),
+        "model": OPENAI_MODEL or "fallback",
+    }
+
+@app.post("/simulate")
+async def simulate_endpoint(request: SimulateRequest):
+    """Evaluate a scenario without touching the blockchain (placeholder)."""
+    return {
+        "simulation": f"Simulated scenario: {request.scenario}",
+        "session_id": request.session_id,
+        "context": (request.context.dict() if request.context else None),
+    }
+
+@app.post("/execute")
+async def execute_endpoint(request: ExecuteRequest):
+    """Trigger a blockchain action (placeholder for now)."""
+    return {
+        "status": f"Executed action: {request.action}",
+        "session_id": request.session_id,
+        "context": (request.context.dict() if request.context else None),
+        "execute_config": request.execute_config,
+    }
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/Querymantua.mjs
+++ b/Querymantua.mjs
@@ -1,0 +1,217 @@
+// mantuaClient.mjs
+// Minimal Mantua client (ESM) with optional context/session & chat streaming
+
+// Ensure fetch exists (Node 18+ or a polyfill like undici)
+if (typeof fetch !== 'function') {
+    throw new Error('Global fetch is not available. Use Node 18+ or polyfill with undici.');
+  }
+  
+  const API_BASE_URL =
+    (typeof process !== "undefined" && process.env?.MANTUA_API_URL) ||
+    "http://localhost:8000"; // your FastAPI server
+  
+  // ---- JSON fetch utility with basic error reporting
+  async function apiRequest(endpoint, method, body = undefined, extraHeaders = {}) {
+    const res = await fetch(`${API_BASE_URL}${endpoint}`, {
+      method,
+      headers: { "Content-Type": "application/json", ...extraHeaders },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`HTTP ${res.status} ${res.statusText}: ${text}`);
+    }
+    const ct = res.headers.get("content-type") || "";
+    return ct.includes("application/json") ? res.json() : res.text();
+  }
+  
+  /** ---------------------------
+   * (Optional) Client-side session
+   * ---------------------------
+   * Mantua has no /session API yet; keep a stable local ID.
+   */
+  function getOrCreateLocalSessionId() {
+    if (typeof window !== "undefined" && window.localStorage) {
+      const key = "mantua_session_id";
+      let id = window.localStorage.getItem(key);
+      if (!id) {
+        id =
+          (typeof crypto !== "undefined" && crypto.randomUUID?.()) ||
+          String(Date.now()) + Math.random().toString(36).slice(2);
+        window.localStorage.setItem(key, id);
+      }
+      return id;
+    }
+    // Node fallback
+    return (typeof crypto !== "undefined" && crypto.randomUUID?.()) ||
+      String(Date.now()) + Math.random().toString(36).slice(2);
+  }
+  
+  // ---------------------------
+  // Streaming helper (fetch + SSE-style parsing)
+  // ---------------------------
+  /**
+   * chatStream — POSTs to /chat with stream=true and invokes onEvent for each SSE "data:" line.
+   * Options:
+   *  - session_id?: string
+   *  - context?: object
+   *  - onEvent?: (data: any) => void
+   */
+  async function chatStream(message, { session_id, context, onEvent } = {}) {
+    const res = await fetch(`${API_BASE_URL}/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message, stream: true, session_id, context }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`HTTP ${res.status} ${res.statusText}: ${text}`);
+    }
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+  
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+  
+      // Split SSE frames by double newline
+      const frames = buf.split("\n\n");
+      buf = frames.pop() || "";
+  
+      for (const frame of frames) {
+        const line = frame.trim();
+        if (!line.startsWith("data:")) continue;
+        const payload = line.slice(5).trim();
+        try {
+          const obj = JSON.parse(payload);
+          onEvent?.(obj);
+        } catch {
+          onEvent?.(payload);
+        }
+      }
+    }
+  }
+  
+  // ---------------------------
+  // Mantua API wrappers
+  // ---------------------------
+  
+  /**
+   * chat — non-streaming chat call.
+   * opts: { session_id?: string, context?: object, stream?: false }
+   */
+  async function chat(message, opts = {}) {
+    const { session_id, context, stream = false } = opts;
+    if (stream) {
+      throw new Error("Use chatStream() for streaming responses.");
+    }
+    const payload = { message, stream: false, session_id, context };
+    const data = await apiRequest("/chat", "POST", payload);
+    return data?.response ?? data;
+  }
+  
+  /**
+   * simulate — dry-run evaluations.
+   * opts: { session_id?: string, context?: object }
+   */
+  async function simulate(scenario, opts = {}) {
+    const { session_id, context } = opts;
+    return apiRequest("/simulate", "POST", { scenario, session_id, context });
+  }
+  
+  /**
+   * execute — live action (placeholder backend).
+   * opts: { session_id?: string, context?: object, execute_config?: object }
+   */
+  async function execute(action, opts = {}) {
+    const { session_id, context, execute_config } = opts;
+    return apiRequest("/execute", "POST", { action, session_id, context, execute_config });
+  }
+  
+  // ---------------------------
+  // Convenience wrappers
+  // ---------------------------
+  
+  async function createSession(title = "Mantua Session") {
+    // Local-only session id for continuity
+    return getOrCreateLocalSessionId();
+  }
+  
+  /**
+   * queryContract — uses /chat with a structured prompt (non-streaming).
+   */
+  async function queryContract(contractAddress, chainId, sessionId, extraContext = undefined) {
+    const message = `
+  Provide a concise, structured overview of the contract at ${contractAddress} on chain ${chainId}.
+  Return strictly in this format:
+  
+  ### Contract Details:
+  - **Name:** <contractName or "Unknown">
+  - **Address:** ${contractAddress}
+  - **Chain ID:** ${chainId}
+  - **Blockchain:** <e.g., Base Sepolia>
+  
+  ### Read-only Functions:
+  1. \`<fnName(params)>\`
+     - **Returns:** <type>
+     - **Description:** <what it does>
+  
+  ### Write-able Functions:
+  1. \`<fnName(params)>\`
+     - **Returns:** <type or "none">
+     - **Description:** <what it does>
+     - **Payable:** <true/false>
+     - **Parameters:** <name> <type> <desc>
+  
+  If a section is empty, say "None available."
+    `.trim();
+  
+    return chat(message, { session_id: sessionId, context: extraContext, stream: false });
+  }
+  
+  /**
+   * handleUserMessage — follow-up chat that threads lightweight context.
+   */
+  async function handleUserMessage(userMessage, sessionId, chainId, contractAddress, extraContext = undefined) {
+    const message = `[context: chain=${chainId}, contract=${contractAddress}] ${userMessage}`;
+    return chat(message, { session_id: sessionId, context: extraContext, stream: false });
+  }
+  
+  /**
+   * executeCommand — adapter to keep old Nebula-style call sites working.
+   * Here we send only the 'action' string your server expects, plus context/config if provided.
+   */
+  async function executeCommand(
+    message,
+    signerWalletAddress,              // currently unused by server
+    userId = "default-user",          // currently unused by server
+    stream = false,                   // use chatStream for streaming chat, not execute
+    chainId = undefined,              // optional, thread via context
+    contractAddress = undefined,      // optional, thread via context
+    sessionId = undefined,            // optional
+    extra = {}                        // { context, execute_config }
+  ) {
+    const context = {
+      ...(extra.context || {}),
+      ...(chainId ? { chain_ids: [String(chainId)] } : {}),
+      ...(contractAddress ? { contract_addresses: [contractAddress] } : {}),
+    };
+    return execute(message, { session_id: sessionId, context, execute_config: extra.execute_config });
+  }
+  
+  export {
+    // core
+    chat,
+    chatStream,
+    simulate,
+    execute,
+    // helpers
+    createSession,
+    queryContract,
+    handleUserMessage,
+    executeCommand,
+  };
+  


### PR DESCRIPTION
## Summary
- add Querymantua.mjs implementing Mantua client with session handling, streaming chat, and API wrappers
- add Main.py FastAPI server providing chat, simulate, and execute endpoints with SSE streaming and OpenAI fallback

## Testing
- `python -m py_compile Main.py`
- `pytest` *(no tests discovered)*
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f684802c8329a09346380832c268